### PR TITLE
Added support to send msg to slack channel via hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build/
 env/
 *.egg-info/
 
+venv/
+
 .tox/
 .coverage
 .cache

--- a/ecs_deploy/slack.py
+++ b/ecs_deploy/slack.py
@@ -2,6 +2,7 @@ import requests
 from os import getenv
 from slacker import Slacker
 
+
 class SlackException(Exception):
     pass
 
@@ -10,11 +11,44 @@ class SlackDeploymentException(SlackException):
     pass
 
 
-class SlackLogger(object):
-    SLACK_ENDPOINT = getenv('SLACK_ENDPOINT')
+class SlackWebhookLogger:
 
     def __init__(self):
-        self.slack = Slacker(getenv('SLACK_TOKEN'))
+        self.slack_webhook_endpoint = getenv('SLACK_WEBHOOK_ENDPOINT')
+
+    def post_to_slack(self, message, attachments):
+        from urllib import request, parse
+        import json
+
+        post = {"text": "{0}".format(message)}
+
+        try:
+            json_data = json.dumps(post)
+            req = request.Request(self.slack_webhook_endpoint,
+                                  data=json_data.encode('ascii'),
+                                  headers={'Content-Type': 'application/json'})
+            resp = request.urlopen(req)
+            print("Post to slack webhook response: " + str(resp))
+        except Exception as em:
+            print("EXCEPTION: " + str(em))
+
+
+class SlackLogger(object):
+
+    def __init__(self):
+        if getenv('SLACK_TOKEN', None) is not None:
+            print('Initializing Slack Token based client')
+            self.slack = Slacker(getenv('SLACK_TOKEN'))
+            self.slack_webhook_endpoint = None
+        elif getenv('SLACK_WEBHOOK_ENDPOINT', None) is not None:
+            print('Initializing Slack Webhook based client')
+            self.slack_webhook_endpoint = SlackWebhookLogger()
+            self.slack = None
+            print('slack webhook endpoint: ' + str(self.slack_webhook_endpoint))
+        else:
+            self.slack = None
+            self.slack_webhook_endpoint = None
+
         self.channel = getenv('SLACK_CHANNEL', "test")
         self.first_post = None
 
@@ -24,12 +58,17 @@ class SlackLogger(object):
         return (progress * chr(9608)) + (pending * chr(9618)) + ((20 - progress - pending) * chr(9617))
 
     def post_to_slack(self, message, attachments):
-      if self.first_post == None:
-          res = self.slack.chat.post_message(self.channel, text=message, attachments=attachments, as_user=True)
-          self.first_post = res.body
-      else:
-          res = self.slack.chat.update(self.first_post['channel'], text=message, attachments=attachments, as_user=True, ts=self.first_post['ts'])
-          res.body
+        if self.slack is not None:
+            if self.first_post == None:
+                res = self.slack.chat.post_message(self.channel, text=message, attachments=attachments, as_user=True)
+                self.first_post = res.body
+            else:
+                res = self.slack.chat.update(self.first_post['channel'], text=message, attachments=attachments, as_user=True, ts=self.first_post['ts'])
+                res.body
+        elif self.slack_webhook_endpoint is not None:
+            self.slack_webhook_endpoint.post_to_slack(message, attachments)
+        else:
+            raise Exception('SLACK_TOKEN (or) SLACK_WEBHOOK_ENDPOINT should to be specified!')
 
     def service_url(self, cluster, service):
         return "https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters/%s/services/%s/deployments" % (cluster, service)
@@ -91,11 +130,12 @@ class SlackLogger(object):
         message = self.get_deploy_start_payload(service, task_definition)
         self.post_to_slack(message, None)
 
-
     def log_deploy_progress(self, service, task_definition):
-        message, attachments = self.get_deploy_progress_payload(service, task_definition)
-        self.post_to_slack(message, attachments)
-
+        if self.slack is not None:
+            message, attachments = self.get_deploy_progress_payload(service, task_definition)
+            self.post_to_slack(message, attachments)
+        else:
+            print('Rendering Deploy Progress in Slack Webhook Mode is Disabled! Need support for posting attachments!')
 
     def log_deploy_finish(self, service, task_definition):
         message, attachments = self.get_deploy_finish_payload(service, task_definition)


### PR DESCRIPTION
- Slack Incoming Webhooks are better solution than Slack Tokens. Updated slack script to accept Slack WebHook Endpoint to post msg to channel. Need to investigate sending progress of deployment via Attachments. Now, Start and Completion of Deployment are posted on Channel referenced by Webhook Endpoint.